### PR TITLE
Use non public try parse when constructing requests

### DIFF
--- a/Src/Library/Extensions/ReflectionExtensions.cs
+++ b/Src/Library/Extensions/ReflectionExtensions.cs
@@ -65,7 +65,7 @@ internal static class ReflectionExtensions
         if (type == Types.Uri)
             return input => (true, new Uri((string)input!));
 
-        var tryParseMethod = type.GetMethod("TryParse", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy, new[] { Types.String, type.MakeByRefType() });
+        var tryParseMethod = type.GetMethod("TryParse", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy, new[] { Types.String, type.MakeByRefType() });
         if (tryParseMethod == null || tryParseMethod.ReturnType != Types.Bool)
             return null;
 

--- a/Src/Library/FastEndpoints.csproj
+++ b/Src/Library/FastEndpoints.csproj
@@ -40,7 +40,7 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <PackageVersion>9.0.3</PackageVersion>
+        <PackageVersion>9.0.4</PackageVersion>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This will fix the issue where ValueObjects couldn't be used as query parameters